### PR TITLE
🔧 Update to use Postgres instance and User Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ This is a [Heroku](https://heroku.com/)-focused container implementation of [n8n
 
 Use the **Deploy to Heroku** button above to launch n8n on Heroku. When deploying, make sure to check all configuration options and adjust them to your needs. It's especially important to set `N8N_ENCRYPTION_KEY` to a random secure value. 
 
-The default credentials for basic authentication is `user:pass`, but you should change this during the initial setup.
-
 Refer to the [Heroku n8n tutorial](https://docs.n8n.io/hosting/server-setups/heroku/) for more information.
 
 If you have questions after trying the tutorials, check out the [forums](https://community.n8n.io/).
-
-## Enabling user management
-
-The default configuration enables basic auth as a fast and simple way to authenticate n8n users. If you prefer the more advanced user management functionality of n8n, add the variables from [this guide](https://docs.n8n.io/hosting/user-management/) to your [Heroku config vars](https://devcenter.heroku.com/articles/config-vars#using-the-heroku-dashboard).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # n8n-heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/n8n-io/n8n-heroku/tree/main)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/n8n-io/n8n-heroku/tree/fix/database-args)
 
 ## n8n - Free and open fair-code licensed node based Workflow Automation Tool.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # n8n-heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/n8n-io/n8n-heroku/tree/fix/database-args)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/n8n-io/n8n-heroku/tree/main)
 
 ## n8n - Free and open fair-code licensed node based Workflow Automation Tool.
 

--- a/app.json
+++ b/app.json
@@ -30,7 +30,7 @@
       },
       "N8N_ENCRYPTION_KEY": {
         "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",
-        "value": "MdRRn2jiZuVeh5tI77A6"
+        "generator": "secret"
       },
       "WEBHOOK_URL": {
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",

--- a/app.json
+++ b/app.json
@@ -12,25 +12,9 @@
     "success_url": "/",
     "stack": "container",
     "env": {
-      "N8N_BASIC_AUTH_ACTIVE": {
-        "description": "Protect n8n setup with basic authentication. Change to `true` if you don't want to use n8n's user management functionality.",
-        "value": "false"
-      },
-      "N8N_USER_MANAGEMENT_DISABLED": {
-        "description": "Disable n8n user management, Set to true if you are using Basic Auth instead.",
-        "value": "false"
-      },
       "GENERIC_TIMEZONE": {
         "description": "Time Zone to use with Heroku. You can find the name of your timezone for example here: https://momentjs.com/timezone/.",
         "value": "Europe/Berlin"
-      },
-      "N8N_BASIC_AUTH_USER": {
-        "description": "Basic Authentication User for n8n. Only required when `N8N_BASIC_AUTH_ACTIVE` is `true`.",
-        "value": "user"
-      },
-      "N8N_BASIC_AUTH_PASSWORD": {
-        "description": "Basic Authentication Password to secure n8n. Only required when `N8N_BASIC_AUTH_ACTIVE` is `true`.",
-        "value": "pass"
       },
       "N8N_ENCRYPTION_KEY": {
         "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",

--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "env": {
       "N8N_BASIC_AUTH_ACTIVE": {
         "description": "Protect n8n setup with basic authentication. Change to `false` if you want to use n8n's user management functionality instead.",
-        "value": "true"
+        "value": "false"
       },
       "GENERIC_TIMEZONE": {
         "description": "Time Zone to use with Heroku. You can find the name of your timezone for example here: https://momentjs.com/timezone/.",
@@ -31,14 +31,6 @@
       "N8N_ENCRYPTION_KEY": {
         "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",
         "value": "MdRRn2jiZuVeh5tI77A6"
-      },
-      "PGSSLMODE": {
-        "description": "SSL is required to connect to Postgres.",
-        "value": "require"
-      },
-      "NODE_TLS_REJECT_UNAUTHORIZED": {
-        "description": "Because Heroku's SSL certificate is self signed, SSL connections fail if this is not set to 0.",
-        "value": "0"
       },
       "WEBHOOK_URL": {
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",

--- a/app.json
+++ b/app.json
@@ -13,7 +13,11 @@
     "stack": "container",
     "env": {
       "N8N_BASIC_AUTH_ACTIVE": {
-        "description": "Protect n8n setup with basic authentication. Change to `false` if you want to use n8n's user management functionality instead.",
+        "description": "Protect n8n setup with basic authentication. Change to `true` if you don't want to use n8n's user management functionality.",
+        "value": "false"
+      },
+      "N8N_USER_MANAGEMENT_DISABLED": {
+        "description": "Disable n8n user management, Set to true if you are using Basic Auth instead.",
         "value": "false"
       },
       "GENERIC_TIMEZONE": {
@@ -30,14 +34,14 @@
       },
       "N8N_ENCRYPTION_KEY": {
         "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",
-        "generator": "secret"
+        "value": "change-me-to-something-else"
       },
       "WEBHOOK_URL": {
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
         "value": "https://<appname>.herokuapp.com"
       },
       "PGSSLMODE": {
-        "description": "SSL is required to connect to Postgreson Heroku",
+        "description": "SSL is required to connect to Postgres on Heroku",
         "value": "no-verify"
       }
     },

--- a/app.json
+++ b/app.json
@@ -38,7 +38,7 @@
       },
       "PGSSLMODE": {
         "description": "SSL is required to connect to Postgreson Heroku",
-        "value": "require"
+        "value": "no-verify"
       }
     },
     "formation": {

--- a/app.json
+++ b/app.json
@@ -35,6 +35,10 @@
       "WEBHOOK_URL": {
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
         "value": "https://<appname>.herokuapp.com"
+      },
+      "PGSSLMODE": {
+        "description": "SSL is required to connect to Postgreson Heroku",
+        "value": "require"
       }
     },
     "formation": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ parse_url() {
 
 # prefix variables to avoid conflicts and run parse url function on arg url
 PREFIX="N8N_DB_" parse_url "$DATABASE_URL"
+echo "$N8N_DB_SCHEME://$N8N_DB_USER:$N8N_DB_PASSWORD@$N8N_DB_HOSTPORT/$N8N_DB_DATABASE"
 # Separate host and port    
 N8N_DB_HOST="$(echo $N8N_DB_HOSTPORT | sed -e 's,:.*,,g')"
 N8N_DB_PORT="$(echo $N8N_DB_HOSTPORT | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ parse_url() {
 
 # prefix variables to avoid conflicts and run parse url function on arg url
 PREFIX="N8N_DB_" parse_url "$DATABASE_URL"
-
+echo "$N8N_DB_SCHEME://$N8N_DB_USER:$N8N_DB_PASSWORD@$N8N_DB_HOSTPORT/$N8N_DB_DATABASE"
 # Separate host and port    
 N8N_DB_HOST="$(echo $N8N_DB_HOSTPORT | sed -e 's,:.*,,g')"
 N8N_DB_PORT="$(echo $N8N_DB_HOSTPORT | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ parse_url() {
 
 # prefix variables to avoid conflicts and run parse url function on arg url
 PREFIX="N8N_DB_" parse_url "$DATABASE_URL"
-echo "$N8N_DB_SCHEME://$N8N_DB_USER:$N8N_DB_PASSWORD@$N8N_DB_HOSTPORT/$N8N_DB_DATABASE"
+
 # Separate host and port    
 N8N_DB_HOST="$(echo $N8N_DB_HOSTPORT | sed -e 's,:.*,,g')"
 N8N_DB_PORT="$(echo $N8N_DB_HOSTPORT | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,23 @@
 # check if port variable is set or go with default
 if [ -z ${PORT+x} ]; then echo "PORT variable not defined, leaving N8N to default port."; else export N8N_PORT="$PORT"; echo "N8N will start on '$PORT'"; fi
 
+# regex function
+parse_url() {
+  eval $(echo "$1" | sed -e "s#^\(\(.*\)://\)\?\(\([^:@]*\)\(:\(.*\)\)\?@\)\?\([^/?]*\)\(/\(.*\)\)\?#${PREFIX:-URL_}SCHEME='\2' ${PREFIX:-URL_}USER='\4' ${PREFIX:-URL_}PASSWORD='\6' ${PREFIX:-URL_}HOSTPORT='\7' ${PREFIX:-URL_}DATABASE='\9'#")
+}
+
+# prefix variables to avoid conflicts and run parse url function on arg url
+PREFIX="N8N_DB_" parse_url "$DATABASE_URL"
+# Separate host and port    
+N8N_DB_HOST="$(echo $N8N_DB_HOSTPORT | sed -e 's,:.*,,g')"
+N8N_DB_PORT="$(echo $N8N_DB_HOSTPORT | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
+
+export DB_TYPE=postgresdb
+export DB_POSTGRESDB_HOST=$N8N_DB_HOST
+export DB_POSTGRESDB_PORT=$N8N_DB_PORT
+export DB_POSTGRESDB_DATABASE=$N8N_DB_DATABASE
+export DB_POSTGRESDB_USER=$N8N_DB_USER
+export DB_POSTGRESDB_PASSWORD=$N8N_DB_PASSWORD
+
 # kickstart nodemation
 n8n

--- a/heroku.yml
+++ b/heroku.yml
@@ -3,11 +3,6 @@ setup:
       - plan: heroku-postgresql
         as: DATABASE
 
-    config:
-        N8N_BASIC_AUTH_ACTIVE: false
-        N8N_BASIC_AUTH_USER: user
-        N8N_BASIC_AUTH_PASSWORD: pass
-
 build:
     docker:
         web: Dockerfile

--- a/heroku.yml
+++ b/heroku.yml
@@ -4,7 +4,7 @@ setup:
         as: DATABASE
 
     config:
-        N8N_BASIC_AUTH_ACTIVE: true
+        N8N_BASIC_AUTH_ACTIVE: false
         N8N_BASIC_AUTH_USER: user
         N8N_BASIC_AUTH_PASSWORD: pass
 


### PR DESCRIPTION
Updates the entrypoint to use the database_url env option created by Heroku
Removes basic auth to prevent any issues with User Management and login loops
Removes the option that allows Node.js to trust all self signed SSL certs