### PR TITLE
fix(app.json): change ssl env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,9 +24,9 @@
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
         "value": "https://<appname>.herokuapp.com"
       },
-      "PGSSLMODE": {
+      "DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED": {
         "description": "SSL is required to connect to Postgres on Heroku",
-        "value": "no-verify"
+        "value": false
       }
     },
     "formation": {


### PR DESCRIPTION
## Why

on latest n8n (v1.15.2), we should use `DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED` to configure SSL, instead of `PGSSLMODE`

see: https://github.com/n8n-io/n8n/issues/7413#issuecomment-1759589578

I've tested the deployment, encountered no problems

## Notes 

I've seen on [another issue](https://github.com/n8n-io/n8n-heroku/pull/7) on this repo that proposes to pin the image version. I can do it here with `1.15.2` if you need