### PR TITLE
Remove formation config

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,12 +29,6 @@
         "value": "no-verify"
       }
     },
-    "formation": {
-      "web": {
-        "quantity": 1,
-        "size": "eco"
-      }
-    },
     "addons": [
       {
         "plan": "heroku-postgresql",


### PR DESCRIPTION
Specifying the size as **eco** is an issue when;
- the Heroku account is a personal account that is not subscribed to the [Eco Dynos Plan][eco]
- the application is under a team where "eco" size is unavailable and the deployment fails.

It's safe to remove the `formation` block fully instead of just the `size` key since the rest of the configuration will be the same as the [default][formation]

[eco]: https://devcenter.heroku.com/articles/eco-dyno-hours#subscribing-to-the-eco-dynos-plan
[formation]: https://devcenter.heroku.com/articles/app-json-schema#formation