### PR TITLE
Update PostgreSQL version from 14 to 16

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "16"
         }
       },
       {


### PR DESCRIPTION
Heroku recently dropped support for PostgreSQL 14, causing deployments failure.

This change bumps the database version to PostgreSQL 16, which is the current stable release and recommended for new applications.