### PR TITLE
Upgrade PostgreSQL version from 14 to 15

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "15"
         }
       },
       {


### PR DESCRIPTION
Previously the deployment on Heroku was failing with the following message:

"""
Configure environment
There was an issue setting up your app environment.

We tried to create heroku-postgresql:essential-0, but received an error from the add-on provider. Try the request again, or log a support ticket and include this message: Unsupported version: 14. We support the following versions: 15, 16, 17
"""

This commit fixes the issue by specifying the relevant version of PostgreSQL - 15 in this case.