### PR TITLE
 update postgres version from 14 to 17

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "17"
         }
       },
       {


### PR DESCRIPTION
 PostgreSQL version 14 for new add-ons, causing deployment failures when using the current template. The error message during app creation is: "Unsupported version: 14. We support the following versions: 15, 16, 17".

This PR updates the PostgreSQL version in `app.json` from 14 to 17, which is fully supported by Heroku and compatible with n8n. This fixes the provisioning issue and allows successful one-click deployments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Heroku Postgres add-on in `app.json` from version `14` to `17` to use a supported PostgreSQL version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b100342986370479d4679c056ecfc7c8a7c605b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->