### PR TITLE
Update PostgreSQL version from 14 to 16 for Heroku compatibility

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "16"
         }
       },
       {


### PR DESCRIPTION
Heroku has deprecated PostgreSQL 14. Updated template to use PostgreSQL 16, which is supported. This fixes deployment failures with the error: 'Unsupported version: 14. We support the following versions: 15, 16, 17'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `app.json` to use Heroku Postgres addon version `16` instead of `14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ba5fd2e3266bbe5f41c2986103b2481c4badb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->