### PR TITLE
Upgrade n8n from 1 22 6 to 1 123 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM n8nio/n8n:latest
 USER root
 
 WORKDIR /home/node/packages/cli
+
+
+COPY ./package.json ./
+COPY ./package-lock.json ./
+
 ENTRYPOINT []
 
 COPY ./entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.0.5
+FROM n8nio/n8n:1.16.0
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.12.1
+FROM n8nio/n8n:1.10.1
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /home/node/packages/cli
 COPY ./package.json ./
 COPY ./package-lock.json ./
 RUN npm install
+RUN cp -a node_modules/. /usr/local/lib/node_modules/
 
 
 ENTRYPOINT []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.15.2
+FROM n8nio/n8n:ai-beta
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:latest
+FROM n8nio/n8n:0.234.1
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:ai-beta
+FROM n8nio/n8n:1.15.2
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:0.234.1
+FROM n8nio/n8n:1.0.5
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ USER root
 WORKDIR /home/node/packages/cli
 
 
+# This let us install packages and used them in the code node
+# note that you will need to update NODE_FUNCTION_ALLOW_EXTERNAL in heroku dashboard
 COPY ./package.json ./
 COPY ./package-lock.json ./
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.15.2
+FROM n8nio/n8n:1.22.6
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.16.0
+FROM n8nio/n8n:1.8.2
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.11.2
+FROM n8nio/n8n:1.15.2
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.8.2
+FROM n8nio/n8n:1.12.1
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /home/node/packages/cli
 
 COPY ./package.json ./
 COPY ./package-lock.json ./
+RUN npm install
+
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.10.1
+FROM n8nio/n8n:1.11.2
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # n8n-heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/n8n-io/n8n-heroku/tree/main)
+Our self-hosted version of n8n available here: https://auto-muzzo-n8n.herokuapp.com
 
-## n8n - Free and open fair-code licensed node based Workflow Automation Tool.
-
-This is a [Heroku](https://heroku.com/)-focused container implementation of [n8n](https://n8n.io/).
-
-Use the **Deploy to Heroku** button above to launch n8n on Heroku. When deploying, make sure to check all configuration options and adjust them to your needs. It's especially important to set `N8N_ENCRYPTION_KEY` to a random secure value. 
-
-Refer to the [Heroku n8n tutorial](https://docs.n8n.io/hosting/server-setups/heroku/) for more information.
-
-If you have questions after trying the tutorials, check out the [forums](https://community.n8n.io/).
+To upgrade the version, see this standard https://www.notion.so/muzzo/Heroku-How-to-update-a-docker-based-app-81fb741210d741ef94766d531d99858b?pvs=4

--- a/app.json
+++ b/app.json
@@ -32,7 +32,7 @@
     "formation": {
       "web": {
         "quantity": 1,
-        "size": "standard-1x"
+        "size": "basic"
       }
     },
     "addons": [

--- a/app.json
+++ b/app.json
@@ -7,8 +7,8 @@
       "automation"
     ],
     "website": "https://n8n.io",
-    "repository": "https://github.com/n8n-io/n8n-heroku",
-    "logo": "https://raw.githubusercontent.com/n8n-io/n8n-heroku/main/n8n_logo.png",
+    "repository": "https://github.com/muzzo-tech/n8n-heroku",
+    "logo": "https://raw.githubusercontent.com/muzzo-tech/n8n-heroku/main/n8n_logo.png",
     "success_url": "/",
     "stack": "container",
     "env": {
@@ -32,7 +32,7 @@
     "formation": {
       "web": {
         "quantity": 1,
-        "size": "eco"
+        "size": "standard-1x"
       }
     },
     "addons": [

--- a/app.json
+++ b/app.json
@@ -24,9 +24,9 @@
         "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
         "value": "https://<appname>.herokuapp.com"
       },
-      "PGSSLMODE": {
+      "DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED": {
         "description": "SSL is required to connect to Postgres on Heroku",
-        "value": "no-verify"
+        "value": "false"
       }
     },
     "formation": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,211 @@
+{
+  "name": "auto-muzzo-n8n",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auto-muzzo-n8n",
+      "version": "0.0.1",
+      "dependencies": {
+        "@hubspot/api-client": "^9.0.0"
+      }
+    },
+    "node_modules/@hubspot/api-client": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hubspot/api-client/-/api-client-9.0.0.tgz",
+      "integrity": "sha512-dwM07fy0NXlSud6BGgUqnUVwBSVWCa3TkAM4nAExn6xsvG6adtA0rD6ljNEGYVdIs0n8wvqAv13vh25fekMbXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.7",
+        "bottleneck": "^2.19.5",
+        "es6-promise": "^4.2.4",
+        "form-data": "^2.5.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "node-fetch": "^2.6.0",
+        "url-parse": "^1.4.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "auto-muzzo-n8n",
+  "version": "0.0.1",
+  "dependencies": {
+    "@hubspot/api-client": "^9.0.0"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded n8n from 1.22.6 to 1.123.5 and enabled external npm modules in Code nodes (adds HubSpot API client). Also updated Heroku config and docs.

- New Features
  - Pin base image to n8nio/n8n:1.123.5.
  - Install npm packages from package.json and expose them to Code nodes.
  - Include @hubspot/api-client by default.

- Migration
  - Set NODE_FUNCTION_ALLOW_EXTERNAL to @hubspot/api-client (and any other needed modules) in Heroku, then redeploy.
  - Replace PGSSLMODE with DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED=false.
  - Formation now uses a basic dyno; confirm or adjust your plan.

<sup>Written for commit 52a4be2612236af43d41d338a2359d4d69f8d72d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

