### PR TITLE
Update PostgreSQL version to 18 in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "18"
         }
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Heroku Postgres from 14 to 18 in app.json so new apps provision on PG 18. This aligns with current defaults and brings performance and security improvements.

- **Migration**
  - Existing databases are unchanged; only new apps/review apps will use PG 18.
  - To upgrade existing environments, run heroku pg:upgrade after verifying extension and client compatibility.

<sup>Written for commit 67785658e253ad6fcc1d6a5fac72ee65fa3f5f95. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

