### PR TITLE
Fix : Update PostgreSQL version from 14 to 17 in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "17"
         }
       },
       {


### PR DESCRIPTION
Update PostgreSQL version from 14 to 17 in app.json to fix deployment issue in Heroku.

Deployment Tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump PostgreSQL from 14 to 17 in app.json to fix Heroku deployment failures. New apps and review apps will provision PG 17; existing databases are unaffected.

<sup>Written for commit 90b154414826b540a7c1c1b13fed48594d7eb0d3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

