### PR TITLE
Sync with main repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM n8nio/n8n:latest
 
 USER root
 
-WORKDIR /home/node/packages/cli
+# Removing the old WORKDIR line as it is not needed for modern n8n
+# Update trigger: v1 (Change this comment to force a rebuild in the future)
+
 ENTRYPOINT []
 
 COPY ./entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM n8nio/n8n:latest
 USER root
 
 # Removing the old WORKDIR line as it is not needed for modern n8n
-# Update trigger: v1 (Change this comment to force a rebuild in the future)
+# Update trigger: v2 (Change this comment to force a rebuild in the future)
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM n8nio/n8n:latest
 USER root
 
 # Removing the old WORKDIR line as it is not needed for modern n8n
-# Update trigger: v2 (Change this comment to force a rebuild in the future)
+# Update trigger: v3 (Change this comment to force a rebuild in the future)
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM n8nio/n8n:latest
 USER root
 
 # Removing the old WORKDIR line as it is not needed for modern n8n
-# Update trigger: v3 (Change this comment to force a rebuild in the future)
+# Update trigger: v4 (Change this comment to force a rebuild in the future)
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM n8nio/n8n:latest
 USER root
 
 # Removing the old WORKDIR line as it is not needed for modern n8n
-# Update trigger: v4 (Change this comment to force a rebuild in the future)
+# Update trigger: v5 (Change this comment to force a rebuild in the future)
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM n8nio/n8n:latest
 USER root
 
 # Removing the old WORKDIR line as it is not needed for modern n8n
-# Update trigger: v5 (Change this comment to force a rebuild in the future)
+# Update trigger: v6 (Change this comment to force a rebuild in the future)
 
 ENTRYPOINT []
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # n8n-heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/n8n-io/n8n-heroku/tree/main)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/AhmedEsawy13/n8n-heroku/tree/main)
 
 ## n8n - Free and open fair-code licensed node based Workflow Automation Tool.
 

--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       {
         "plan": "heroku-postgresql",
         "options": {
-          "version": "14"
+          "version": "15"
         }
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Modernizes Docker and Heroku setup: removes an outdated Docker `WORKDIR`, upgrades Heroku Postgres to 15, and updates the deploy button to this repo. Adds a comment-based trigger to force Docker rebuilds.

- **Refactors**
  - Removed unnecessary `WORKDIR` for modern `n8nio/n8n` usage.
  - Added comment trigger to force Docker image rebuilds.
  - Updated README deploy link to this repository.

- **Dependencies**
  - Upgraded `heroku-postgresql` add-on version to 15 in `app.json`.

<sup>Written for commit 8ef13af3a7378438d9b254bec63aaebc79e16fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-heroku/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

